### PR TITLE
Upload artefact on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
           path: "docs/CHANGELOG.md"
           version: ${{ github.ref_name }}
 
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.10.1
+      - name : Create Helm-package
+        run: make helm-package
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -32,3 +38,4 @@ jobs:
           draft: true
           prerelease: false
           body: ${{ steps.changelog.outputs.changes }}
+          files: out-helm/*


### PR DESCRIPTION
For RKE2, we need the archive of the helm.

Ref https://github.com/outscale/osc-bsu-csi-driver/issues/623