### PR TITLE
Fix E2E test after runner Docker upgrade

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -53,7 +53,7 @@ jobs:
         osc_region: ${{ secrets.OSC_REGION }}
     - name: Build image
       run: |
-        make build-image image-tag
+        make buildx-image image-tag
       env:
         REGISTRY_IMAGE: localhost:4242/osc/cloud-provider-osc
         VERSION: ${{ format('{0}.{1}', github.sha, github.run_attempt) }}

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ test:
 build-image:
 	docker build --build-arg VERSION=$(VERSION) -t $(IMAGE):$(IMAGE_TAG) .
 
+.PHONY: buildx-image
+buildx-image:
+	docker buildx build  --build-arg VERSION=$(VERSION) --load -t $(IMAGE):$(IMAGE_TAG) .
+
 .PHONY: dockerlint
 dockerlint:
 	@echo "Lint images =>  $(DOCKERFILES)"


### PR DESCRIPTION
This PR is for fixing build of docker after last upgrade of runner 

See https://github.com/outscale-mdr/osc-bsu-csi-driver/actions/runs/4405177787/jobs/7783208526

⚠️ The CI will fail because we have modified the GH Action 