### PR TITLE
✨ feat(loadbalancer): filter backend nodes

### DIFF
--- a/cloud-controller-manager/osc/cloud/loadbalancer.go
+++ b/cloud-controller-manager/osc/cloud/loadbalancer.go
@@ -126,6 +126,7 @@ type LoadBalancer struct {
 	SecurityGroups           []string          `annotation:"osc-load-balancer-security-group"`
 	AdditionalSecurityGroups []string          `annotation:"osc-load-balancer-extra-security-groups"`
 	TargetRole               string            `annotation:"osc-load-balancer-target-role"`
+	TargetNodesLabels        map[string]string `annotation:"osc-load-balancer-target-node-labels"`
 	Tags                     map[string]string `annotation:"osc-load-balancer-additional-resource-tags"`
 	HealthCheck              HealthCheck       `annotation:",squash"`
 	ListenerDefaults         ListenerDefaults  `annotation:",squash"`

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -3,7 +3,7 @@
 The supported Service annotations are:
 
 | Annotation | Default | Mutable | Description
-| --- | --- | ---
+| --- | --- | --- | ---
 | service.beta.kubernetes.io/osc-load-balancer-name | n/a | No | The load balancer name (will be truncated to 32 chars).
 | service.beta.kubernetes.io/osc-load-balancer-internal | `false` | No | Is it an internal LBU or a public one ?
 | service.beta.kubernetes.io/osc-load-balancer-subnet-id | n/a | No | The subnet in which to create the load balancer.
@@ -11,8 +11,9 @@ The supported Service annotations are:
 | service.beta.kubernetes.io/osc-load-balancer-ip-id | n/a | No | The ID of the public IP to use.
 | service.beta.kubernetes.io/osc-load-balancer-security-group | n/a | No | The main security group of the load balancer, if not set, a new SG will be created.
 | service.beta.kubernetes.io/osc-load-balancer-extra-security-groups | n/a | No | Additional security groups to be added
-| service.beta.kubernetes.io/osc-load-balancer-additional-resource-tags | n/a | No | A comma-separated list of key=value pairs which to be added as additional tags in the LBU. For example: `Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2`
-| service.beta.kubernetes.io/osc-load-balancer-target-role | `worker` | No | The role of backend server nodes
+| service.beta.kubernetes.io/osc-load-balancer-additional-resource-tags | n/a | No | A comma-separated list of key=value tags to be added to the LBU. For example: `Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2`
+| service.beta.kubernetes.io/osc-load-balancer-target-role | `worker` | Yes | The role of backend server nodes, used to search the target node security group.
+| service.beta.kubernetes.io/osc-load-balancer-target-node-labels | n/a | Yes | A comma-separated list of key=value labels the backend server nodes need to have.
 | service.beta.kubernetes.io/osc-load-balancer-proxy-protocol | n/a | Yes | A comma-separated list of backend ports that will use proxy protocol. Set to value `*` to enable proxy protocol on all backends.
 | service.beta.kubernetes.io/osc-load-balancer-backend-protocol | n/a | Yes | The protocol to use to talk to backend pods. If `http` or `https`, an HTTPS listener that terminates the connection and parses headers is created. If set to `ssl` or `tcp`, a "raw" SSL listener is used. If set to `http` and `osc-load-balancer-ssl-cert` is not used then a HTTP listener is used.
 | service.beta.kubernetes.io/osc-load-balancer-ssl-cert | n/a | Yes | The ORN of the certificate to use with a SSL/HTTPS listener. See https://docs.outscale.com/en/userguide/About-Server-Certificates-in-EIM.html for more info.


### PR DESCRIPTION
A `service.beta.kubernetes.io/osc-load-balancer-target-node-labels` annotation can be set on the service.

This enables the load-balancer to have only the nodes with the specified labels as backend VMs.

No check is made that the target nodes are the ones where the target pods are running.

Fixes #465