### PR TITLE
🐛 fix(loadbalancer): CCM upgrade would recreate all listeners

### DIFF
--- a/cloud-controller-manager/osc/cloud/loadbalancer.go
+++ b/cloud-controller-manager/osc/cloud/loadbalancer.go
@@ -286,13 +286,10 @@ func (l *LoadBalancer) listeners() []osc.ListenerForCreation {
 		var protocol string
 		backendProtocol := strings.ToLower(l.ListenerDefaults.BackendProtocol)
 		if l.ListenerDefaults.SSLCertificate != "" && isPortIn(lstnr.Port, l.ListenerDefaults.SSLPorts) {
-			switch {
-			case backendProtocol == "http":
+			switch backendProtocol {
+			case "http", "https":
 				protocol = "https"
-			case backendProtocol == "" && lstnr.Port == 443:
-				protocol = "https"
-				backendProtocol = "http"
-			case backendProtocol == "":
+			case "":
 				protocol = "ssl"
 				backendProtocol = "tcp"
 			default:
@@ -300,13 +297,10 @@ func (l *LoadBalancer) listeners() []osc.ListenerForCreation {
 			}
 			olstnr.ServerCertificateId = ptr.To(l.ListenerDefaults.SSLCertificate)
 		} else {
-			switch {
-			case backendProtocol == "http":
+			switch backendProtocol {
+			case "http":
 				protocol = "http"
-			case backendProtocol == "" && lstnr.Port == 80:
-				protocol = "http"
-				backendProtocol = "http"
-			case backendProtocol == "":
+			case "":
 				protocol = "tcp"
 				backendProtocol = "tcp"
 			default:

--- a/cloud-controller-manager/osc/helpers_test.go
+++ b/cloud-controller-manager/osc/helpers_test.go
@@ -155,9 +155,9 @@ func expectReadLoadBalancer(mock *oapimocks.MockOAPI, updates ...func(*sdk.LoadB
 		Subnets:          &[]string{"subnet-service"},
 		Listeners: &[]sdk.Listener{{
 			LoadBalancerPort:     ptr.To[int32](80),
-			LoadBalancerProtocol: ptr.To("HTTP"),
+			LoadBalancerProtocol: ptr.To("TCP"),
 			BackendPort:          ptr.To[int32](8080),
-			BackendProtocol:      ptr.To("HTTP"),
+			BackendProtocol:      ptr.To("TCP"),
 		}},
 		HealthCheck: &sdk.HealthCheck{
 			HealthyThreshold:   2,
@@ -202,9 +202,9 @@ func expectCreateLoadBalancer(mock *oapimocks.MockOAPI, updates ...func(*sdk.Cre
 		}},
 		Listeners: []sdk.ListenerForCreation{{
 			LoadBalancerPort:     80,
-			LoadBalancerProtocol: "HTTP",
+			LoadBalancerProtocol: "TCP",
 			BackendPort:          8080,
-			BackendProtocol:      ptr.To("HTTP"),
+			BackendProtocol:      ptr.To("TCP"),
 		}},
 	}
 	for _, update := range updates {
@@ -476,9 +476,9 @@ func expectCreateListener(mock *oapimocks.MockOAPI, port int32) {
 			LoadBalancerName: "lb-foo",
 			Listeners: []sdk.ListenerForCreation{{
 				LoadBalancerPort:     port,
-				LoadBalancerProtocol: "HTTP",
+				LoadBalancerProtocol: "TCP",
 				BackendPort:          8080,
-				BackendProtocol:      ptr.To("HTTP"),
+				BackendProtocol:      ptr.To("TCP"),
 			}},
 		})).
 		Return(&sdk.LoadBalancer{}, nil)


### PR DESCRIPTION
Protocols were computed differently, forcing the CCM to recreate all listener with the new protocol
