### PR TITLE
✨ feat: allow custom cluster id

### DIFF
--- a/cloud-controller-manager/osc/provider.go
+++ b/cloud-controller-manager/osc/provider.go
@@ -59,14 +59,14 @@ type Provider struct {
 func NewProvider(ctx context.Context, opts Options) (*Provider, error) {
 	klog.V(2).Infof("Starting OSC cloud provider")
 
-	c, err := cloud.New(ctx, os.Getenv(""))
+	c, err := cloud.New(ctx, os.Getenv("OSC_CLUSTER_ID"))
 	if err != nil {
 		return nil, fmt.Errorf("init: %w", err)
 	}
 
 	self := c.Self
-	klog.V(3).Infof("OSC CCM Instance (%s)", self.ID)
-	klog.V(3).Infof("OSC CCM vpcID (%s)", self.NetID)
+	klog.V(3).Infof("Instance: %q", self.ID)
+	klog.V(3).Infof("VPC: %q", self.NetID)
 	return &Provider{
 		opts:  opts,
 		cloud: c,

--- a/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
+++ b/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
@@ -192,6 +192,10 @@ spec:
             - name: NO_PROXY
               value: {{ .Values.noProxy }}
             {{- end }}
+            {{- if .Values.customClusterID }}
+            - name: OSC_CLUSTER_ID
+              value: {{ .Values.customClusterID }}
+            {{- end }}
       volumes:
       {{- if .Values.caBundle.name }}
         - name: ca-bundle

--- a/deploy/k8s-osc-ccm/values.yaml
+++ b/deploy/k8s-osc-ccm/values.yaml
@@ -73,3 +73,6 @@ resources: {}
 #   key2: value2
 # -- Add extra tags on load-balancers
 extraLoadBalancerTags: {}
+
+# -- Set this if you want to use a specific cluster ID instead of the automatically computed one. Use with caution.
+customClusterID: ''

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -27,6 +27,7 @@ Kubernetes: `>=1.20.0-0`
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]}]}}}` | Assign Pod to Nodes (see [kubernetes doc](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)) |
 | caBundle.key | string | `""` | Entry key in secret used to store additional certificates authorities |
 | caBundle.name | string | `""` | Secret name containing additional certificates authorities |
+| customClusterID | string | `""` | Set this if you want to use a specific cluster ID instead of the automatically computed one. Use with caution. |
 | customEndpoint | string | `""` | Use customEndpoint (url with protocol) ex: https://api.eu-west-2.outscale.com/api/v1 |
 | customEndpointEim | string | `""` | Use customEndpointEim (url with protocol) ex: https://eim.eu-west-2.outscale.com     |
 | customEndpointFcu | string | `""` | Use customEndpointFcu (url with protocol) ex: https://fcu.eu-west-2.outscale.com |


### PR DESCRIPTION
The Cluster ID is computed:
- by searching the OscK8sClusterID tag of the node VM,
- by getting the UID of the kube-system namespace.

This PR allows the user to set a custom ID in case the computation gives an invalid answer.

v0.2.8 fetched the node VM tags or used an undocumented AWS config file.