### PR TITLE
🥅 errors: handle when no subnet is found

### DIFF
--- a/cloud-controller-manager/osc/cloud/loadbalancer.go
+++ b/cloud-controller-manager/osc/cloud/loadbalancer.go
@@ -538,6 +538,8 @@ func (c *Cloud) ensureSubnet(ctx context.Context, l *LoadBalancer) error {
 	case l.Internal && ensureByTag("OscK8sRole/service.internal"):
 	case ensureByTag("OscK8sRole/service"):
 	case ensureByTag("OscK8sRole/loadbalancer"):
+	default:
+		return errors.New("no subnet found with the correct tag")
 	}
 	return nil
 }

--- a/cloud-controller-manager/osc/helpers_test.go
+++ b/cloud-controller-manager/osc/helpers_test.go
@@ -313,6 +313,19 @@ func expectFindLBSubnet(mock *oapimocks.MockOAPI) {
 		}, nil)
 }
 
+func expectFindNoLBSubnet(mock *oapimocks.MockOAPI) {
+	mock.EXPECT().
+		ReadSubnets(gomock.Any(), gomock.Eq(sdk.ReadSubnetsRequest{
+			Filters: &sdk.FiltersSubnet{
+				TagKeys: &[]string{"OscK8sClusterID/foo"},
+			},
+		})).
+		Return([]sdk.Subnet{
+			{SubnetId: ptr.To("subnet-service"), Tags: &[]sdk.ResourceTag{}},
+			{SubnetId: ptr.To("subnet-service.internal"), Tags: &[]sdk.ResourceTag{}},
+		}, nil)
+}
+
 func expectCreateSecurityGroup(mock *oapimocks.MockOAPI) {
 	mock.EXPECT().
 		CreateSecurityGroup(gomock.Any(), gomock.Eq(sdk.CreateSecurityGroupRequest{

--- a/cloud-controller-manager/osc/loadbalancer_test.go
+++ b/cloud-controller-manager/osc/loadbalancer_test.go
@@ -101,7 +101,17 @@ func TestEnsureLoadBalancer_Create(t *testing.T) {
 		_, err := p.EnsureLoadBalancer(context.TODO(), "foo", svc, []*v1.Node{&vmNode})
 		require.Error(t, err)
 	})
-	t.Run("A public LB is created and a retryable error is returned when not ready", func(t *testing.T) {
+	t.Run("Cannot create a load-balancer if no subnet is found", func(t *testing.T) {
+		svc := testSvc()
+		c, oapimock, _ := newAPI(t, self, "foo")
+		expectVMs(oapimock, sdkSelf, sdkVM)
+		expectNoLoadbalancer(oapimock)
+		expectFindNoLBSubnet(oapimock)
+		p := osc.NewProviderWith(c)
+		_, err := p.EnsureLoadBalancer(context.TODO(), "foo", svc, []*v1.Node{&vmNode})
+		require.Error(t, err)
+	})
+	t.Run("A public LB is created, and a retryable error is returned if it is not ready", func(t *testing.T) {
 		svc := testSvc()
 		c, oapimock, lbmock := newAPI(t, self, "foo")
 		expectVMs(oapimock, sdkSelf, sdkVM)


### PR DESCRIPTION
## Description

When no subnet is found, return an error and do not try to create a LBU.

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [X] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
