### PR TITLE
🐛 fix: ccm was broken outside eu-west-2

### DIFF
--- a/.github/scripts/runneraksk.sh
+++ b/.github/scripts/runneraksk.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+az=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+region=`echo $az|sed 's/[a-d]$//'`
+suffix=`echo $region|tr '[:lower:]' '[:upper:]'|sed -r 's/-/_/g'`
+echo "OSC_SUBREGION_NAME=$az" | tee -a $GITHUB_ENV
+echo "OSC_REGION=$region" | tee -a $GITHUB_ENV
+echo "OSC_ACCESS_KEY_NAME=OSC_ACCESS_KEY_$suffix" | tee -a $GITHUB_ENV
+echo "OSC_SECRET_KEY_NAME=OSC_SECRET_KEY_$suffix" | tee -a $GITHUB_ENV
+echo "OSC_ACCOUNT_ID_NAME=OSC_ACCOUNT_ID_$suffix" | tee -a $GITHUB_ENV

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -17,7 +17,7 @@ on:
     
 jobs:
   create_cluster:
-    runs-on: [self-hosted, linux, eu-west-2]
+    runs-on: [self-hosted, linux]
     steps:
     - name: ⬇️ Checkout
       uses: actions/checkout@v4
@@ -33,12 +33,14 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+    - name: 🔐 Set ak/sk name based on runner region
+      run: .github/scripts/runneraksk.sh
     - name: 🧹 Frieza
       uses: outscale/frieza-github-actions/frieza-clean@master
       with:
-        access_key: ${{ secrets.OSC_ACCESS_KEY }}
-        secret_key: ${{ secrets.OSC_SECRET_KEY }}
-        region: ${{ secrets.OSC_REGION }}
+        access_key: ${{ secrets[env.OSC_ACCESS_KEY_NAME] }}
+        secret_key: ${{ secrets[env.OSC_SECRET_KEY_NAME] }}
+        region: ${{ env.OSC_REGION }}
     - name: 📦 Build and push Docker image 
       run: |
         docker login ${{ vars.REGISTRY }} -u admin -p ${{ secrets.HARBOR_ADMIN_PASSWORD }}
@@ -50,9 +52,9 @@ jobs:
     - name: 🧪 Test on VPC cluster
       uses: ./.github/local_action/start_ccm_e2e
       with:
-        osc_access_key: ${{ secrets.OSC_ACCESS_KEY }}
-        osc_secret_key: ${{ secrets.OSC_SECRET_KEY }}
-        osc_region: ${{ secrets.OSC_REGION }}
+        osc_access_key: ${{ secrets[env.OSC_ACCESS_KEY_NAME] }}
+        osc_secret_key: ${{ secrets[env.OSC_SECRET_KEY_NAME] }}
+        osc_region: ${{ env.OSC_REGION }}
         oks_access_key: ${{ secrets.OKS_ACCESS_KEY }}
         oks_secret_key: ${{ secrets.OKS_SECRET_KEY }}
         oks_region: ${{ vars.OKS_REGION }}
@@ -64,9 +66,9 @@ jobs:
     # - name: 🧪 Test on Public cluster
     #   uses: ./.github/local_action/start_ccm_e2e
     #   with:
-    #     osc_access_key: ${{ secrets.OSC_ACCESS_KEY }}
-    #     osc_secret_key: ${{ secrets.OSC_SECRET_KEY }}
-    #     osc_region: ${{ secrets.OSC_REGION }}
+    #     osc_access_key: ${{ secrets[env.OSC_ACCESS_KEY_NAME] }}
+    #     osc_secret_key: ${{ secrets[env.OSC_SECRET_KEY_NAME] }}
+    #     osc_region: ${{ env.OSC_REGION }}
     #     public_cloud: "true"
     #     image_id: ${{ secrets.OMI_ID }}
     #     version: ${{ format('{0}.{1}', github.sha, github.run_attempt) }}

--- a/cloud-controller-manager/osc/oapi/client.go
+++ b/cloud-controller-manager/osc/oapi/client.go
@@ -49,7 +49,7 @@ func NewClient(region string) (*Client, error) {
 		return nil, fmt.Errorf("new client: %w", err)
 	}
 	aws := elb.New(sess)
-	oapi, err := NewOscClient(configEnv)
+	oapi, err := NewOscClient(region, configEnv)
 	if err != nil {
 		return nil, fmt.Errorf("new client: %w", err)
 	}

--- a/cloud-controller-manager/osc/oapi/client_oapi.go
+++ b/cloud-controller-manager/osc/oapi/client_oapi.go
@@ -32,7 +32,8 @@ type OscClient struct {
 }
 
 // NewOscClient builds an OAPI client.
-func NewOscClient(configEnv *osc.ConfigEnv) (*OscClient, error) {
+func NewOscClient(region string, configEnv *osc.ConfigEnv) (*OscClient, error) {
+	configEnv.Region = &region
 	config, err := configEnv.Configuration()
 	if err != nil {
 		return nil, fmt.Errorf("load osc config: %w", err)


### PR DESCRIPTION
## Description

The OAPI client was configured without region and switched to the default eu-west-2.

Fixes: #475 

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

CI needs to be updated to run in us-east-2 as well as eu-west-2.