### PR TITLE
🚀 helm: add v0/v1 compatible helm chart

### DIFF
--- a/.github/local_action/start_ccm_e2e/action.yml
+++ b/.github/local_action/start_ccm_e2e/action.yml
@@ -60,7 +60,7 @@ runs:
         kubectl create secret generic osc-secret --from-literal=access_key=${{ inputs.osc_access_key }} --from-literal=secret_key=${{ inputs.osc_secret_key }} --from-literal=region=${{ inputs.osc_region }} \
           -n kube-system
         echo "installing CCM"
-        helm install --wait k8s-osc-ccm deploy/k8s-osc-ccm --set oscSecretName=osc-secret --set image.repository=${{ inputs.registry }}/outscale/cloud-provider-osc --set image.tag=${{ inputs.version }} \
+        helm install --wait k8s-osc-ccm deploy/k8s-osc-ccm --set oscSecretName=osc-secret --set image.repository=${{ inputs.registry }}/outscale/cloud-provider-osc --set oscSecretFormat=v1 --set image.tag=${{ inputs.version }} \
           --set extraLoadBalancerTags.clikey=clivalue
         echo "waiting for worker nodes"
         kubectl wait --for=condition=Ready nodes --all --timeout=900s
@@ -96,7 +96,7 @@ runs:
         profile="{\"default\":{\"access_key\":\"${{ inputs.osc_access_key }}\",\"secret_key\":\"${{ inputs.osc_secret_key }}\"}}"
         kubectl create secret generic osc-secret-file --from-literal=config.json=$profile -n kube-system
         echo "updating CCM config"
-        helm upgrade --wait k8s-osc-ccm deploy/k8s-osc-ccm --set oscSecretName=osc-secret-file --set oscCredentialsFromFile=true --set image.repository=${{ inputs.registry }}/outscale/cloud-provider-osc --set image.tag=${{ inputs.version }}\
+        helm upgrade --wait k8s-osc-ccm deploy/k8s-osc-ccm --set oscSecretName=osc-secret-file --set oscCredentialsFromFile=true --set oscSecretFormat=v1 --set image.repository=${{ inputs.registry }}/outscale/cloud-provider-osc --set image.tag=${{ inputs.version }}\
           --set extraLoadBalancerTags.clikey=clivalue
         echo "waiting for pods"
         kubectl wait --for=condition=Ready po --all -A --timeout=900s

--- a/deploy/k8s-osc-ccm/Chart.yaml
+++ b/deploy/k8s-osc-ccm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.2.8"
 description: A Helm chart for OSC CCM cloud provider
 name: osc-cloud-controller-manager
-version: 0.4.0
+version: 0.5.0
 kubeVersion: ">=1.20.0-0"
 home: https://github.com/outscale/cloud-provider-osc/
 sources:

--- a/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
+++ b/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
@@ -165,18 +165,81 @@ spec:
           {{- end }}
           env:
             {{- if not .Values.oscCredentialsFromFile }}
+            {{- if eq .Values.oscSecretFormat "v1" }}
             - name: OSC_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.oscSecretName | default "osc-secret" }}
                   key: access_key
-                  optional: false
+                  optional: true
             - name: OSC_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.oscSecretName | default "osc-secret" }}
                   key: secret_key
+                  optional: true
+            {{- else }}
+            - name: OSC_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: osc_account_id
+                  optional: true
+            - name: OSC_ACCOUNT_IAM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: osc_account_iam
+                  optional: true
+            - name: OSC_USER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: osc_user_id
+                  optional: true
+            - name: OSC_ARN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: osc_arn
+                  optional: true
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: key_id
                   optional: false
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: access_key
+                  optional: false
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: aws_default_region
+                  optional: false
+            - name: AWS_AVAILABILITY_ZONES
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: aws_availability_zones
+                  optional: true
+            - name: OSC_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: access_key
+                  optional: false
+            - name: OSC_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oscSecretName | default "osc-secret" }}
+                  key: key_id
+                  optional: false
+            {{- end }}
             {{- if .Values.customEndpoint }}
             - name: OSC_ENDPOINT_API
               value: {{ .Values.customEndpoint }}

--- a/deploy/k8s-osc-ccm/values.yaml
+++ b/deploy/k8s-osc-ccm/values.yaml
@@ -24,6 +24,8 @@ image:
 verbose: 5
 # -- Secret name containing cloud credentials
 oscSecretName: osc-secret
+# -- Set to v1 if deploying a v1 image, v0 otherwise.
+oscSecretFormat: v0
 # -- Set if credentials are read from a [profile file](https://docs.outscale.com/en/userguide/Installing-and-Configuring-oapi-cli.html#_configuring_oapi_cli) stored in `/root/.osc/config.json`. If `oscSecretName` is set, the secret is mounted as `/root/.osc` and is expected to have a `config.json` key.
 oscCredentialsFromFile: false
 # -- Specify image pull secrets

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,6 +1,6 @@
 # osc-cloud-controller-manager
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![AppVersion: 0.2.8](https://img.shields.io/badge/AppVersion-0.2.8-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 0.2.8](https://img.shields.io/badge/AppVersion-0.2.8-informational?style=flat-square)
 
 A Helm chart for OSC CCM cloud provider
 
@@ -41,6 +41,7 @@ Kubernetes: `>=1.20.0-0`
 | noProxy | string | `""` | Value used to create environment variable NO_PROXY |
 | nodeSelector | object | `{}` | Assign Pod to Nodes (see [kubernetes doc](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)) |
 | oscCredentialsFromFile | bool | `false` | Set if credentials are read from a [profile file](https://docs.outscale.com/en/userguide/Installing-and-Configuring-oapi-cli.html#_configuring_oapi_cli) stored in `/root/.osc/config.json`. If `oscSecretName` is set, the secret is mounted as `/root/.osc` and is expected to have a `config.json` key. |
+| oscSecretFormat | string | `"v0"` | Set to v1 if deploying a v1 image, v0 otherwise. |
 | oscSecretName | string | `"osc-secret"` | Secret name containing cloud credentials |
 | podLabels | object | `{}` | Labels for pod |
 | replicaCount | int | `1` | Number of replicas to deploy |


### PR DESCRIPTION
## Description

The v1.0.0-alpha.1 release updated the current helm chart with a v0 incompatible config.

This PR adds a v0/v1 compatible Helm chart.

To deploy a v1 image, the `--set oscSecretFormat=v1` needs to be added to the helm command.

Fixes: #484 

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing (v0/v1)
- [ ] Unit tests
- [X] E2E tests (v1)
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
