### PR TITLE
👽️ load-balancer: set ingress IP for better integration with IP-based services

### DIFF
--- a/cloud-controller-manager/osc/loadbalancer.go
+++ b/cloud-controller-manager/osc/loadbalancer.go
@@ -56,18 +56,18 @@ func (c *Provider) EnsureLoadBalancer(ctx context.Context, clusterName string, s
 	}
 
 	var (
-		dns string
+		dns, ip string
 	)
 	if exists {
-		dns, err = c.cloud.UpdateLoadBalancer(ctx, lb, vms)
+		dns, ip, err = c.cloud.UpdateLoadBalancer(ctx, lb, vms)
 	} else {
-		dns, err = c.cloud.CreateLoadBalancer(ctx, lb, vms) // Note: no DNS is expected to be returned after creation
+		dns, ip, err = c.cloud.CreateLoadBalancer(ctx, lb, vms) // Note: no DNS is expected to be returned after creation
 	}
 	switch {
 	case err != nil:
 		return nil, err
 	case dns != "":
-		return &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{Hostname: dns}}}, nil
+		return &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{Hostname: dns, IP: ip}}}, nil
 	default:
 		return &v1.LoadBalancerStatus{}, nil
 	}
@@ -110,7 +110,7 @@ func (c *Provider) UpdateLoadBalancer(ctx context.Context, clusterName string, s
 		return err
 	}
 
-	_, err = c.cloud.UpdateLoadBalancer(ctx, lb, vms)
+	_, _, err = c.cloud.UpdateLoadBalancer(ctx, lb, vms)
 	return err
 }
 

--- a/cloud-controller-manager/osc/loadbalancer_test.go
+++ b/cloud-controller-manager/osc/loadbalancer_test.go
@@ -579,6 +579,27 @@ func TestEnsureLoadBalancer_Update(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
+		})
+		expectDescribeProxyProtocol(lbmock, false)
+		expectDescribeLoadBalancerAttributes(lbmock)
+		expectFindExistingIngressSecurityGroup(oapimock, "sg-foo")
+		expectFindExistingWorkerSG(oapimock)
+		p := osc.NewProviderWith(c)
+		status, err := p.EnsureLoadBalancer(context.TODO(), "foo", svc, []*v1.Node{&vmNode})
+		require.NoError(t, err)
+		assert.Equal(t, &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{Hostname: "foo.example.com", IP: "198.51.100.42"}}}, status)
+	})
+	t.Run("When retrying creation on an internal LBU, the status is properly returned when ready, without IP", func(t *testing.T) {
+		svc := testSvc()
+		svc.Annotations["service.beta.kubernetes.io/osc-load-balancer-internal"] = "true"
+		c, oapimock, lbmock := newAPI(t, self, "foo")
+		expectLoadbalancerExistsAndOwned(oapimock)
+		expectVMs(oapimock, sdkSelf, sdkVM)
+		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
+			desc.LoadBalancerType = ptr.To("internal")
+			desc.DnsName = ptr.To("foo.example.com")
+			desc.BackendVmIds = &[]string{"i-foo"}
 		})
 		expectDescribeProxyProtocol(lbmock, false)
 		expectDescribeLoadBalancerAttributes(lbmock)
@@ -598,6 +619,7 @@ func TestEnsureLoadBalancer_Update(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDeleteListener(oapimock)
 		expectCreateListener(oapimock, 8080)
@@ -623,6 +645,7 @@ func TestEnsureLoadBalancer_Update(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, false)
 		expectConfigureProxyProtocol(lbmock, false, true)
@@ -642,6 +665,7 @@ func TestEnsureLoadBalancer_Update(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, true)
 		expectDescribeLoadBalancerAttributes(lbmock)
@@ -659,6 +683,7 @@ func TestEnsureLoadBalancer_Update(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, true)
 		expectConfigureProxyProtocol(lbmock, true, false)
@@ -681,6 +706,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDeleteListener(oapimock)
 		expectCreateListener(oapimock, 8080)
@@ -707,6 +733,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 			desc.GetListeners()[0].LoadBalancerProtocol = ptr.To("https")
 			desc.GetListeners()[0].BackendProtocol = ptr.To("http")
 			desc.GetListeners()[0].ServerCertificateId = ptr.To("arn:aws:service:region:account:resource")
@@ -734,6 +761,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, false)
 		expectDescribeLoadBalancerAttributes(lbmock)
@@ -769,6 +797,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, false)
 		expectDescribeLoadBalancerAttributes(lbmock)
@@ -785,6 +814,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		expectVMs(oapimock, sdkSelf, sdkVM)
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, false)
 		expectDescribeLoadBalancerAttributes(lbmock)
@@ -803,6 +833,7 @@ func TestUpdateLoadBalancer(t *testing.T) {
 		expectReadLoadBalancer(oapimock, func(desc *sdk.LoadBalancer) {
 			desc.DnsName = ptr.To("foo.example.com")
 			desc.BackendVmIds = &[]string{"i-foo", "i-bar"}
+			desc.PublicIp = ptr.To("198.51.100.42")
 		})
 		expectDescribeProxyProtocol(lbmock, false)
 		expectDescribeLoadBalancerAttributes(lbmock)

--- a/tests/e2e/loadbalancer.go
+++ b/tests/e2e/loadbalancer.go
@@ -99,6 +99,13 @@ var _ = Describe("[e2e][loadbalancer][fast] Creating a load-balancer", func() {
 			}
 		})
 
+		It("ingress is configured", func() {
+			svc = e2eutils.WaitForSvc(ctx, cs, svc)
+			gomega.Expect(svc.Status.LoadBalancer.Ingress, gomega.Not(gomega.BeEmpty()))
+			gomega.Expect(svc.Status.LoadBalancer.Ingress[0].Hostname, gomega.Not(gomega.BeEmpty()))
+			gomega.Expect(svc.Status.LoadBalancer.Ingress[0].IP, gomega.Not(gomega.BeEmpty()))
+		})
+
 		It("can connect to the load-balancer", func() {
 			svc = e2eutils.WaitForSvc(ctx, cs, svc)
 			e2esvc.TestReachableHTTP(ctx, svc.Status.LoadBalancer.Ingress[0].Hostname, 80, testTimeout)


### PR DESCRIPTION
## Description

Some services (e.g. Kamaji) require a load-balancer ingress to have an IP.

This PR adds the IP in addition to the Hostname.

This only works with internet facing LBU.

Side-effect of this change: as the Public IP is configured later that the DNS name, kube needs to retry EnsureLoadBalancer before having a complete ingress configuration, and therefore `status.loadBalancer` configuration is delayed. The global LBU readiness delay is not expected to change.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
