### PR TITLE
[WIP] Always create the LoadBalancer in the same net of its subnet

### DIFF
--- a/cloud-controller-manager/osc/cloud/loadbalancer.go
+++ b/cloud-controller-manager/osc/cloud/loadbalancer.go
@@ -119,10 +119,11 @@ type AccessLog struct {
 type LoadBalancer struct {
 	Name                     string `annotation:"osc-load-balancer-name"`
 	ServiceName              string
-	Internal                 bool              `annotation:"osc-load-balancer-internal"`
-	PublicIPPool             string            `annotation:"osc-load-balancer-ip-pool"`
-	PublicIPID               string            `annotation:"osc-load-balancer-ip-id"`
-	SubnetID                 string            `annotation:"osc-load-balancer-subnet-id"`
+	Internal                 bool   `annotation:"osc-load-balancer-internal"`
+	PublicIPPool             string `annotation:"osc-load-balancer-ip-pool"`
+	PublicIPID               string `annotation:"osc-load-balancer-ip-id"`
+	SubnetID                 string `annotation:"osc-load-balancer-subnet-id"`
+	NetID                    string
 	SecurityGroups           []string          `annotation:"osc-load-balancer-security-group"`
 	AdditionalSecurityGroups []string          `annotation:"osc-load-balancer-extra-security-groups"`
 	TargetRole               string            `annotation:"osc-load-balancer-target-role"`
@@ -529,6 +530,7 @@ func (c *Cloud) ensureSubnet(ctx context.Context, l *LoadBalancer) error {
 		for _, subnet := range subnets {
 			if hasTag(subnet.GetTags(), key) {
 				l.SubnetID = subnet.GetSubnetId()
+				l.NetID = subnet.GetNetId()
 				return true
 			}
 		}
@@ -555,7 +557,7 @@ func (c *Cloud) ensureSecurityGroup(ctx context.Context, l *LoadBalancer) error 
 	resp, err := c.api.OAPI().CreateSecurityGroup(ctx, osc.CreateSecurityGroupRequest{
 		SecurityGroupName: sgName,
 		Description:       sgDescription,
-		NetId:             &c.Self.NetID,
+		NetId:             &l.NetID,
 	})
 	if err != nil {
 		return fmt.Errorf("create SG: %w", err)

--- a/cloud-controller-manager/osc/provider.go
+++ b/cloud-controller-manager/osc/provider.go
@@ -72,7 +72,6 @@ func NewProvider(ctx context.Context, opts Options) (*Provider, error) {
 
 	self := c.Self
 	klog.V(3).Infof("Instance: %q", self.ID)
-	klog.V(3).Infof("VPC: %q", self.NetID)
 	return &Provider{
 		opts:     opts,
 		cloud:    c,


### PR DESCRIPTION
## Description

Always enforce the loadbalancer creation in the same net of the subnet we found

Fixes: #501

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [ ] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

Need to fix the test actually
