### PR TITLE
✨ feat(loadbalancer): add service.beta.kubernetes.io/osc-load-balancer-ingress-address annotation

### DIFF
--- a/cloud-controller-manager/osc/cloud/loadbalancer.go
+++ b/cloud-controller-manager/osc/cloud/loadbalancer.go
@@ -56,6 +56,7 @@ var (
 		ListenerDefaults: ListenerDefaults{
 			SSLPorts: []string{"*"},
 		},
+		IngressAddress: Hostname,
 	}
 	// ErrLoadBalancerIsNotReady is returned by CreateLoadBalancer/UpdateLoadBalancer when the LB is not ready yet.
 	ErrLoadBalancerIsNotReady = controllerapi.NewRetryError("load balancer is not ready", 30*time.Second)
@@ -115,6 +116,22 @@ type AccessLog struct {
 	BucketPrefix string `annotation:"osc-load-balancer-access-log-oos-bucket-prefix"`
 }
 
+type IngressAddress string
+
+const (
+	Hostname IngressAddress = "hostname"
+	IP       IngressAddress = "ip"
+	Both     IngressAddress = "both"
+)
+
+func (i IngressAddress) NeedHostname() bool {
+	return i == Hostname || i == Both
+}
+
+func (i IngressAddress) NeedIP() bool {
+	return i == IP || i == Both
+}
+
 // LoadBalancer defines a load-balancer.
 type LoadBalancer struct {
 	Name                     string `annotation:"osc-load-balancer-name"`
@@ -135,6 +152,7 @@ type LoadBalancer struct {
 	SessionAffinity          string
 	AccessLog                AccessLog `annotation:",squash"`
 	AllowFrom                utilnet.IPNetSet
+	IngressAddress           IngressAddress `annotation:"osc-load-balancer-ingress-address"`
 
 	lbSecurityGroup     *osc.SecurityGroup
 	targetSecurityGroup *osc.SecurityGroup
@@ -370,17 +388,17 @@ func (c *Cloud) getLoadBalancer(ctx context.Context, l *LoadBalancer) (*osc.Load
 }
 
 // GetLoadBalancer fetches a load-balancer.
-func (c *Cloud) GetLoadBalancer(ctx context.Context, l *LoadBalancer) (dns string, found bool, err error) {
+func (c *Cloud) GetLoadBalancer(ctx context.Context, l *LoadBalancer) (dns, ip string, found bool, err error) {
 	lb, err := c.getLoadBalancer(ctx, l)
 	switch {
 	case err != nil:
-		return "", false, fmt.Errorf("unable to get LB: %w", err)
+		return "", "", false, fmt.Errorf("unable to get LB: %w", err)
 	case lb == nil:
-		return "", false, nil
+		return "", "", false, nil
 	case lb.DnsName != nil:
-		return *lb.DnsName, true, nil
+		return lb.GetDnsName(), lb.GetPublicIp(), true, nil
 	default:
-		return "", true, nil
+		return "", "", true, nil
 	}
 }
 

--- a/cloud-controller-manager/osc/cloud/loadbalancer_config_test.go
+++ b/cloud-controller-manager/osc/cloud/loadbalancer_config_test.go
@@ -54,8 +54,9 @@ func TestNewLoadBalancer(t *testing.T) {
 				HealthyThreshold:   cloud.DefaultLoadBalancerConfiguration.HealthCheck.HealthyThreshold,
 				UnhealthyThreshold: cloud.DefaultLoadBalancerConfiguration.HealthCheck.UnhealthyThreshold,
 			},
-			AllowFrom:  ipNetSet("0.0.0.0/0"),
-			Connection: cloud.Connection{IdleTimeout: 60},
+			AllowFrom:      ipNetSet("0.0.0.0/0"),
+			Connection:     cloud.Connection{IdleTimeout: 60},
+			IngressAddress: cloud.Hostname,
 		},
 	}, {
 		name: "Annotations are loaded",
@@ -91,6 +92,7 @@ func TestNewLoadBalancer(t *testing.T) {
 					"service.beta.kubernetes.io/osc-load-balancer-connection-draining-enabled":     "true",
 					"service.beta.kubernetes.io/osc-load-balancer-connection-draining-timeout":     "47",
 					"service.beta.kubernetes.io/osc-load-balancer-connection-idle-timeout":         "48",
+					"service.beta.kubernetes.io/osc-load-balancer-ingress-address":                 "both",
 					"service.beta.kubernetes.io/load-balancer-source-ranges":                       "192.0.2.0/24,198.51.100.0/24",
 				},
 			},
@@ -143,7 +145,8 @@ func TestNewLoadBalancer(t *testing.T) {
 				"foo":    "bar",
 				"foobar": "barbar",
 			},
-			AllowFrom: ipNetSet("192.0.2.0/24", "198.51.100.0/24"),
+			AllowFrom:      ipNetSet("192.0.2.0/24", "198.51.100.0/24"),
+			IngressAddress: cloud.Both,
 		},
 	}, {
 		name: "Tags are merged with the global config",
@@ -190,6 +193,7 @@ func TestNewLoadBalancer(t *testing.T) {
 				"foobar": "barbar",
 				"foobaz": "bazbaz",
 			},
+			IngressAddress: cloud.Hostname,
 		},
 	}, {
 		name: "AWS annotations are loaded",
@@ -273,7 +277,8 @@ func TestNewLoadBalancer(t *testing.T) {
 				"foo":    "bar",
 				"foobar": "barbar",
 			},
-			AllowFrom: ipNetSet("192.0.2.0/24", "198.51.100.0/24"),
+			AllowFrom:      ipNetSet("192.0.2.0/24", "198.51.100.0/24"),
+			IngressAddress: cloud.Hostname,
 		},
 	}, {
 		name: "Source ranges can be set in the spec",
@@ -307,8 +312,9 @@ func TestNewLoadBalancer(t *testing.T) {
 				HealthyThreshold:   cloud.DefaultLoadBalancerConfiguration.HealthCheck.HealthyThreshold,
 				UnhealthyThreshold: cloud.DefaultLoadBalancerConfiguration.HealthCheck.UnhealthyThreshold,
 			},
-			AllowFrom:  ipNetSet("192.0.2.0/24", "198.51.100.0/24"),
-			Connection: cloud.Connection{IdleTimeout: 60},
+			AllowFrom:      ipNetSet("192.0.2.0/24", "198.51.100.0/24"),
+			Connection:     cloud.Connection{IdleTimeout: 60},
+			IngressAddress: cloud.Hostname,
 		},
 	}}
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -32,4 +32,5 @@ The supported Service annotations are:
 | service.beta.kubernetes.io/osc-load-balancer-connection-draining-enabled | n/a | Yes | Enable connection draining.
 | service.beta.kubernetes.io/osc-load-balancer-connection-draining-timeout | n/a | Yes | The connection draining timeout.
 | service.beta.kubernetes.io/osc-load-balancer-connection-idle-timeout | `60` | Yes | The idle connection timeout.
+| service.beta.kubernetes.io/osc-load-balancer-ingress-address | `hostname` | Yes | Defines what information is set in `status.loadBalancer.ingress`: `hostname`, `ip` or `both` (sets both ip and hostname).
 | service.beta.kubernetes.io/load-balancer-source-ranges | n/a | Yes | The IP source ranges allowed to call the load balancer.


### PR DESCRIPTION
## Description

A new `service.beta.kubernetes.io/osc-load-balancer-ingress-address` is added to configure whether `status.loadBalancer.ingress` will have a hostname, an ip, or both.

As both may generate issues with Cillium, the PR changes the default format used by v1.0.0 (both) to the safer v0 format (hostname).
  
Fixes: #507 

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [ ] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [ ] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
