### PR TITLE
🚀 prepare v1.31.0/v1.32.0/1.33.0 releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,9 @@ check-helm-docs:
 	./hack/verify-helm-docs
 
 helm-manifest:
-	@helm template test ./deploy/k8s-osc-ccm/ --values deploy/k8s-osc-ccm/values.yaml > deploy/osc-ccm-manifest.yml
+	@helm template test ./deploy/k8s-osc-ccm/ --set image.tag=v1.31.0 > deploy/osc-ccm-manifest-v1.31.yml
+	@helm template test ./deploy/k8s-osc-ccm/ --set image.tag=v1.32.0 > deploy/osc-ccm-manifest-v1.32.yml
+	@helm template test ./deploy/k8s-osc-ccm/ --set image.tag=v1.33.0 > deploy/osc-ccm-manifest-v1.33.yml
 
 check-helm-manifest:
 	./hack/verify-helm-manifest.sh

--- a/deploy/helm_test.go
+++ b/deploy/helm_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func getHelmSpecs(t *testing.T, vars []string) []runtime.Object {
-	args := []string{"template", "--debug"}
+	args := []string{"template", "--debug", "--set", "image.tag=foo"}
 	if len(vars) > 0 {
 		args = append(args, "--set", strings.Join(vars, ","))
 	}

--- a/deploy/k8s-osc-ccm/Chart.yaml
+++ b/deploy/k8s-osc-ccm/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "1.0.1"
+appVersion: "1.31.0/1.32.0/1.33.0"
 description: A Helm chart for OSC CCM cloud provider
 name: osc-cloud-controller-manager
-version: 0.6.1
-kubeVersion: ">=1.20.0-0"
+version: 0.7.0
+kubeVersion: ">=1.30.0-0"
 home: https://github.com/outscale/cloud-provider-osc/
 sources:
   - https://github.com/outscale/cloud-provider-osc/

--- a/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
+++ b/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
@@ -140,7 +140,7 @@ spec:
       {{- end }}
       containers:
         - name: osc-cloud-controller-manager
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ .Values.image.repository }}:{{ required "image.tag needs to be set to the version matching your Kubernetes version" .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/osc-cloud-controller-manager

--- a/deploy/k8s-osc-ccm/values.yaml
+++ b/deploy/k8s-osc-ccm/values.yaml
@@ -15,8 +15,8 @@ customEndpointEim: ""
 image:
   # -- Container image to use
   repository: outscale/cloud-provider-osc
-  # -- Container image tag to deploy
-  tag: v1.0.1
+  # -- Container image tag to deploy, you need to use the version matching your Kubernetes version.
+  tag:
   # -- Container pull policy
   pullPolicy: IfNotPresent
 

--- a/deploy/osc-ccm-manifest-v1.31.yml
+++ b/deploy/osc-ccm-manifest-v1.31.yml
@@ -1,0 +1,186 @@
+---
+# Source: osc-cloud-controller-manager/templates/serviceaccount.yaml
+# ServiceAccount Def
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - node-controller
+  - service-controller
+  - route-controller
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+# CCM Service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager:apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: osc-cloud-controller-manager
+  name: osc-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: osc-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: osc-cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: osc-cloud-controller-manager
+          image: outscale/cloud-provider-osc:v1.31.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/osc-cloud-controller-manager
+            - --configure-cloud-routes=false
+            - --cloud-provider=osc
+            - -v=5
+          resources:
+            {}
+          env:
+            - name: OSC_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: osc-secret
+                  key: access_key
+                  optional: true
+            - name: OSC_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: osc-secret
+                  key: secret_key
+                  optional: true
+      hostNetwork: true
+      affinity: 
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+      nodeSelector: 
+        {}
+      tolerations: 
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane

--- a/deploy/osc-ccm-manifest-v1.32.yml
+++ b/deploy/osc-ccm-manifest-v1.32.yml
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: osc-cloud-controller-manager
-          image: outscale/cloud-provider-osc:v1.0.1
+          image: outscale/cloud-provider-osc:v1.32.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/osc-cloud-controller-manager

--- a/deploy/osc-ccm-manifest-v1.33.yml
+++ b/deploy/osc-ccm-manifest-v1.33.yml
@@ -1,0 +1,186 @@
+---
+# Source: osc-cloud-controller-manager/templates/serviceaccount.yaml
+# ServiceAccount Def
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - node-controller
+  - service-controller
+  - route-controller
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+# CCM Service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager:apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+# Source: osc-cloud-controller-manager/templates/osc-ccm.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: osc-cloud-controller-manager
+  name: osc-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: osc-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: osc-cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: osc-cloud-controller-manager
+          image: outscale/cloud-provider-osc:v1.33.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/osc-cloud-controller-manager
+            - --configure-cloud-routes=false
+            - --cloud-provider=osc
+            - -v=5
+          resources:
+            {}
+          env:
+            - name: OSC_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: osc-secret
+                  key: access_key
+                  optional: true
+            - name: OSC_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: osc-secret
+                  key: secret_key
+                  optional: true
+      hostNetwork: true
+      affinity: 
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+      nodeSelector: 
+        {}
+      tolerations: 
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [v1.33.0] - 2025-11-19
+
+### ✨ Added
+* ✨feat(loadbalancer): implement ipmode by @moh2a in https://github.com/outscale/cloud-provider-osc/pull/518
+### 🛠️ Changed / Refactoring
+* 🔊 logs: fix LBU response logging / switch to Go 1.25 by @jfbus in https://github.com/outscale/cloud-provider-osc/pull/519
+
+## [v1.32.0] - 2025-11-19
+
+### ✨ Added
+* ✨feat(loadbalancer): implement ipmode by @moh2a in https://github.com/outscale/cloud-provider-osc/pull/518
+### 🛠️ Changed / Refactoring
+* 🔊 logs: fix LBU response logging / switch to Go 1.25 by @jfbus in https://github.com/outscale/cloud-provider-osc/pull/519
+
+## [v1.31.0] - 2025-11-19
+
+### ✨ Added
+* ✨feat(loadbalancer): implement ipmode by @moh2a in https://github.com/outscale/cloud-provider-osc/pull/518
+### 🛠️ Changed / Refactoring
+* 🔊 logs: fix LBU response logging / switch to Go 1.25 by @jfbus in https://github.com/outscale/cloud-provider-osc/pull/519
+
+## [helm-v0.7.0] - 2025-11-19
+
+### 🐛 Fixed
+* 🐛 fix(helm): fix empty volume/volumeMounts blocks by @jfbus in https://github.com/outscale/cloud-provider-osc/pull/527
+
 ## [v1.0.1] - 2025-10-13
 
 Change: by default, v1.0.1 only returns the hostname of a load-balancer ingress instead of hostname + IP.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,15 +8,46 @@ This component is required to operate a cluster on the OUTSCALE Cloud.
 More details on the [cloud-controller role](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) in a Kubernetes cluster.
 
 # Features
-- Node controller: provides information and status about nodes,
+- Node controller: manages nodes and node metadata,
 - Service controller: allows creation of LoadBalancer services, based on [Load Balancer Units (LBU)](https://docs.outscale.com/en/userguide/About-Load-Balancers.html). 
 
 # Installation
+
+## Kubernetes version support
+
+Each Kubernetes version requires a specific CCM version.
+
+CCM versions use the same major and minor version numbers as their corresponding Kubernetes releases. Patch version numbering is specific to the Outscale CCM and does not match Kubernetes patch releases.
+
+E.g. Kubernetes v1.32.x will need CCM v1.32.y.
+
+CCM v0.2.8 can be safely used with Kubernetes 1.30.x, and CCM v1.0.x can be safely used with Kubernetes 1.32.x.
+
+CCM versions are available for Kubernetes 1.31, 1.32, and 1.33. As Kubernetes 1.31 has reached end of life (EOL), CCM v1.31 releases will be discontinued in the near future. Support for Kubernetes 1.34 will be added soon.
+
+## Support matrix
+
+| Kubernetes version | Recommended CCM version |
+|--------------------|-------------------------|
+| v1.30.x            | v0.2.8                  |
+| v1.31.x            | v1.31.0                 |
+| v1.32.x            | v1.32.0                 |
+| v1.33.x            | v1.33.0                 |
+| v1.34.x            | to be released          |
+
+## Deployment on a new cluster
+
 See the [deployment documentation](../deploy/README.md)
 
-# Upgrading to v1.0
+## Upgrading a cluster to a new Kubernetes version
 
-Annotations have changed, but the old ones remain valid. You do not need to update your existing LoadBalancer services.
+When upgrading a cluster, the CCM needs to be upgraded for the target Kubernetes version before the creation of the new nodes.
+
+Nodes created with a mismatched CCM version might not be properly configured.
+
+## Upgrading CCM from v0 to v1
+
+Annotations have changed, but the old ones still work. You do not need to update your existing LoadBalancer services.
 
 The secret has now the same format as the CSI driver. You need to rename:
 * `key_id` to `access_key`,

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,9 +114,15 @@ make build-image image-tag image-push helm_deploy test-e2e
 3.  Update cloud-provider-osc version in [values.yaml](../deploy/k8s-osc-ccm/values.yaml)
 4.  Update prerequisites section in [deploy/README.md](../deploy/README.md)
 5.  Generate helm doc `make helm-docs`
-6.  Update version in [deploy/osc-ccm-manifest.yml](../deploy/osc-ccm-manifest.yml)
+6.  Update [deploy/osc-ccm-manifest.yml](../deploy/osc-ccm-manifest.yml) `make helm-manifest`
 7.  Commit version with `git commit -am "cloud-controller-manager vX.Y.Z"`
 8.  Create PR and merge it to main
-9.  Create Tag with `git tag vX.Y.Z` on main
-10. Push tag on Github
+9. Tag the release
+```shell
+git tag -a vX.X.X -m "🔖 Release vX.X.X"
+```
+10. Push the tag
+```shell
+git push origin vX.X.X
+```
 11. Publish the release on Github

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,6 +1,6 @@
 # osc-cloud-controller-manager
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: 1.31.0/1.32.0/1.33.0](https://img.shields.io/badge/AppVersion-1.31.0/1.32.0/1.33.0-informational?style=flat-square)
 
 A Helm chart for OSC CCM cloud provider
 
@@ -18,7 +18,7 @@ A Helm chart for OSC CCM cloud provider
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.30.0-0`
 
 ## Values
 
@@ -36,7 +36,7 @@ Kubernetes: `>=1.20.0-0`
 | httpsProxy | string | `""` | Value used to create environment variable HTTPS_PROXY |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"outscale/cloud-provider-osc"` | Container image to use |
-| image.tag | string | `"v1.0.1"` | Container image tag to deploy |
+| image.tag | string | `nil` | Container image tag to deploy, you need to use the version matching your Kubernetes version. |
 | imagePullSecrets | list | `[]` | Specify image pull secrets |
 | noProxy | string | `""` | Value used to create environment variable NO_PROXY |
 | nodeSelector | object | `{}` | Assign Pod to Nodes (see [kubernetes doc](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)) |

--- a/hack/verify-helm-manifest.sh
+++ b/hack/verify-helm-manifest.sh
@@ -4,4 +4,4 @@ set -e
 
 make helm-manifest
 
-git diff --exit-code deploy/osc-ccm-manifest.yml
+git diff --exit-code deploy/osc-ccm-manifest*


### PR DESCRIPTION
There should be a version of the CCM for each major Kubernetes release.

* CCM v1.31.0 is compatible with Kubernetes v1.31.x
* CCM v1.32.0 is compatible with Kubernetes v1.32.x
* CCM v1.33.0 is compatible with Kubernetes v1.33.x

Notes:

CCM versioning & compatibility matrix has been moved from the deployment README to the main README.