### PR TITLE
👷 release: disable changelog parsing in helm releases

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -1,4 +1,4 @@
-name: Release 
+name: Publish Helm 
 
 on:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release 
+name: Publish 
 
 on:
   release:

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -1,5 +1,4 @@
-# Github action for releasing the binaries
-name: release
+name: Release Helm
 
 on:
   push:
@@ -18,12 +17,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Get changelog for release
-        id: changelog
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          path: "docs/CHANGELOG.md"
-          version: ${{ github.ref_name }}
+      # - name: Get changelog for release
+      #   id: changelog
+      #   uses: mindsers/changelog-reader-action@v2
+      #   with:
+      #     path: "docs/CHANGELOG.md"
+      #     version: ${{ github.ref_name }}
       - uses: azure/setup-helm@v4
         with:
           version: v3.18.3
@@ -37,5 +36,5 @@ jobs:
           name: Helm Release ${{ github.ref_name }}
           draft: true
           prerelease: false
-          body: ${{ steps.changelog.outputs.changes }}
+          # body: ${{ steps.changelog.outputs.changes }}
           files: out-helm/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
-# Github action for releasing the binaries
-name: release
+name: Release
 
 on:
   push:


### PR DESCRIPTION
## Description

mindsers/changelog-reader-action seems to have problems with the `helm-vX` tag format.

This PR disables the action until a solution is found.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
