### PR TITLE
👷 build: use vX-helm tags instead of helm-vX for helm releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,7 @@ updates:
       prefix: "⬆️ deps: "
     ignore:
       - dependency-name: k8s.io/*
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
       - dependency-name: sigs.k8s.io/*
-        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    groups:
-      k8s:
-        applies-to: version-updates
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-        update-types:
-          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   push-helm-chart:
-    if: startsWith(github.ref, 'refs/tags/helm')
+    if: ${{ contains(github.ref, 'helm') }}
     runs-on: ubuntu-22.04
     steps:
       - name: Check the repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   push-image:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{ !contains(github.ref, 'helm') }}
     runs-on: ubuntu-22.04
     steps:
       - name: Check the repo

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -3,7 +3,7 @@ name: Release Helm
 on:
   push:
     tags:
-    - 'helm-v*'
+    - 'v*'
   workflow_dispatch:  
     
 permissions:
@@ -11,18 +11,19 @@ permissions:
 
 jobs:
   release-helm:
+    if: ${{ contains(github.ref, 'helm') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      # - name: Get changelog for release
-      #   id: changelog
-      #   uses: mindsers/changelog-reader-action@v2
-      #   with:
-      #     path: "docs/CHANGELOG.md"
-      #     version: ${{ github.ref_name }}
+      - name: Get changelog for release
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          path: "docs/CHANGELOG.md"
+          version: ${{ github.ref_name }}
       - uses: azure/setup-helm@v4
         with:
           version: v3.18.3
@@ -36,5 +37,5 @@ jobs:
           name: Helm Release ${{ github.ref_name }}
           draft: true
           prerelease: false
-          # body: ${{ steps.changelog.outputs.changes }}
+          body: ${{ steps.changelog.outputs.changes }}
           files: out-helm/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ !contains(github.ref, 'helm') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/deploy/k8s-osc-ccm/.helmignore
+++ b/deploy/k8s-osc-ccm/.helmignore
@@ -20,3 +20,5 @@
 .idea/
 *.tmproj
 .vscode/
+.helmignore
+helm_test.go

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/outscale/osc-sdk-go/v2 v2.29.0
 	github.com/rs/xid v1.6.0
-	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.0
 	go.uber.org/mock v0.6.0
 )
@@ -31,12 +30,12 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 )
 
 // Kubernetes imports, isolated to avoid conflicts in version branches.
 require (
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.32.8
 	k8s.io/apimachinery v0.32.8
 	k8s.io/client-go v0.32.8
@@ -139,6 +138,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/time v0.7.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
 	google.golang.org/grpc v1.65.0 // indirect

--- a/hack/update-release-branches.sh
+++ b/hack/update-release-branches.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+oldbranch=`git rev-parse --abbrev-ref HEAD`
+git co main
+git pull --rebase
+for branch in `git branch | egrep 'kubernetes-'`; do
+    echo "** $branch"
+    git co $branch
+    git pull --rebase
+    git rebase main
+done
+git co $oldbranch


### PR DESCRIPTION
## Description

This PR improves the release process:
- change helm release tags to allow changelog parsing
- move some go.mod entries to limit conflicts
- add release branch resync script
- stop dependabot from upgrading kube in main (using manual updates in version branches for now)

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

