### PR TITLE
🐛 fix: nodes should be removed when terminated

### DIFF
--- a/cloud-controller-manager/osc/cloud/vm.go
+++ b/cloud-controller-manager/osc/cloud/vm.go
@@ -96,6 +96,10 @@ func (vm *VM) IsStopped() bool {
 	return vm.cloudVm.GetState() == "stopped"
 }
 
+func (vm *VM) IsTerminated() bool {
+	return vm.cloudVm.GetState() == "terminated"
+}
+
 // InstanceID returns the instance ID
 func (vm *VM) InstanceID() string {
 	return "/" + vm.cloudVm.Placement.GetSubregionName() + "/" + vm.cloudVm.GetVmId()

--- a/cloud-controller-manager/osc/instances_v2_test.go
+++ b/cloud-controller-manager/osc/instances_v2_test.go
@@ -22,9 +22,19 @@ func TestInstanceExists(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, exists)
 	})
-	t.Run("If the instance does not exists, return true", func(t *testing.T) {
+	t.Run("If the instance does not exists, return false", func(t *testing.T) {
 		c, mock, _ := newAPI(t, self, "foo")
 		expectVMs(mock, sdkSelf)
+		p := osc.NewProviderWith(c, nil)
+		exists, err := p.InstanceExists(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+	t.Run("If the instance is terminated, return false", func(t *testing.T) {
+		sdkTerminated := sdkVM
+		sdkTerminated.State = ptr.To("terminated")
+		c, mock, _ := newAPI(t, self, "foo")
+		expectVMs(mock, sdkSelf, sdkTerminated)
 		p := osc.NewProviderWith(c, nil)
 		exists, err := p.InstanceExists(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

When a VM is in terminated state, InstanceExists should return false.

Fixes: #545 

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
