### PR TITLE
🐛 fix(lb): fix public ip

### DIFF
--- a/cloud-controller-manager/osc/helpers_test.go
+++ b/cloud-controller-manager/osc/helpers_test.go
@@ -614,3 +614,9 @@ func expectPublicIPFromPool(mock *oapimocks.MockOAPI, ips []sdk.PublicIp) {
 		ListPublicIpsFromPool(gomock.Any(), gomock.Eq("pool-foo")).
 		Return(ips, nil)
 }
+
+func expectPublicIP(mock *oapimocks.MockOAPI, id string, ip *sdk.PublicIp) {
+	mock.EXPECT().
+		GetPublicIp(gomock.Any(), gomock.Eq(id)).
+		Return(ip, nil)
+}

--- a/cloud-controller-manager/osc/oapi/interfaces.go
+++ b/cloud-controller-manager/osc/oapi/interfaces.go
@@ -40,6 +40,7 @@ type OAPI interface {
 	RegisterVmsInLoadBalancer(ctx context.Context, req osc.RegisterVmsInLoadBalancerRequest) error
 	DeregisterVmsInLoadBalancer(ctx context.Context, req osc.DeregisterVmsInLoadBalancerRequest) error
 
+	GetPublicIp(ctx context.Context, id string) (*osc.PublicIp, error)
 	ListPublicIpsFromPool(ctx context.Context, pool string) ([]osc.PublicIp, error)
 
 	ReadSecurityGroups(ctx context.Context, req osc.ReadSecurityGroupsRequest) ([]osc.SecurityGroup, error)

--- a/cloud-controller-manager/osc/oapi/mocks/mock_oapi.go
+++ b/cloud-controller-manager/osc/oapi/mocks/mock_oapi.go
@@ -201,6 +201,21 @@ func (mr *MockOAPIMockRecorder) DeregisterVmsInLoadBalancer(ctx, req any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterVmsInLoadBalancer", reflect.TypeOf((*MockOAPI)(nil).DeregisterVmsInLoadBalancer), ctx, req)
 }
 
+// GetPublicIp mocks base method.
+func (m *MockOAPI) GetPublicIp(ctx context.Context, id string) (*osc.PublicIp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicIp", ctx, id)
+	ret0, _ := ret[0].(*osc.PublicIp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicIp indicates an expected call of GetPublicIp.
+func (mr *MockOAPIMockRecorder) GetPublicIp(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicIp", reflect.TypeOf((*MockOAPI)(nil).GetPublicIp), ctx, id)
+}
+
 // ListPublicIpsFromPool mocks base method.
 func (m *MockOAPI) ListPublicIpsFromPool(ctx context.Context, pool string) ([]osc.PublicIp, error) {
 	m.ctrl.T.Helper()

--- a/cloud-controller-manager/osc/oapi/oapi.go
+++ b/cloud-controller-manager/osc/oapi/oapi.go
@@ -78,6 +78,22 @@ func (c *OscClient) ReadVms(ctx context.Context, req osc.ReadVmsRequest) ([]osc.
 	return resp.GetVms(), nil
 }
 
+func (c *OscClient) GetPublicIp(ctx context.Context, id string) (*osc.PublicIp, error) {
+	req := osc.ReadPublicIpsRequest{
+		Filters: &osc.FiltersPublicIp{PublicIpIds: &[]string{id}},
+	}
+	resp, httpRes, err := c.api.PublicIpApi.ReadPublicIps(c.WithAuth(ctx)).ReadPublicIpsRequest(req).Execute()
+	err = logAndExtractError(ctx, "ReadPublicIps", req, httpRes, err)
+	switch {
+	case err != nil:
+		return nil, err
+	case len(resp.GetPublicIps()) == 0:
+		return nil, errors.New("not found")
+	default:
+		return &resp.GetPublicIps()[0], nil
+	}
+}
+
 func (c *OscClient) ListPublicIpsFromPool(ctx context.Context, pool string) ([]osc.PublicIp, error) {
 	req := osc.ReadPublicIpsRequest{
 		Filters: &osc.FiltersPublicIp{


### PR DESCRIPTION
## Description

The `osc-load-balancer-ip-id` is broken, as it passes the public ip id to CreateLoadBalancer, which expects an IP.

Fixes: #559 

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [x] E2E tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
