### PR TITLE
🐛 fix: work on clusters with mismatched CAPOSC v0/v1 tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.1
+        version: v2.7.1
         args: --timeout=300s
         only-new-issues: true
     - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.25.4
+ARG GOLANG_IMAGE=golang:1.25.5
 
 # The distroless image on which the CPI manager image is built.
 #

--- a/cloud-controller-manager/osc/cloud/cloud.go
+++ b/cloud-controller-manager/osc/cloud/cloud.go
@@ -3,8 +3,11 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/outscale/cloud-provider-osc/cloud-controller-manager/osc/oapi"
+	"github.com/outscale/cloud-provider-osc/cloud-controller-manager/utils"
+	"github.com/outscale/osc-sdk-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -14,7 +17,7 @@ type Cloud struct {
 	api       oapi.Clienter
 	Metadata  oapi.Metadata
 	Self      *VM
-	clusterID string
+	clusterID []string
 }
 
 func New(ctx context.Context, clusterID string) (*Cloud, error) {
@@ -30,7 +33,7 @@ func New(ctx context.Context, clusterID string) (*Cloud, error) {
 	if err := api.OAPI().CheckCredentials(ctx); err != nil {
 		return nil, fmt.Errorf("init cloud: %w", err)
 	}
-	c := &Cloud{api: api, Metadata: metadata, clusterID: clusterID}
+	c := &Cloud{api: api, Metadata: metadata}
 
 	id := c.Metadata.InstanceID
 	self, err := c.GetVMByID(ctx, id)
@@ -38,8 +41,29 @@ func New(ctx context.Context, clusterID string) (*Cloud, error) {
 		return nil, fmt.Errorf("error finding self: %w", err)
 	}
 	c.Self = self
-	if c.clusterID == "" {
-		c.clusterID = self.ClusterID()
+	if clusterID != "" {
+		c.clusterID = []string{clusterID}
+	} else {
+		// primary cluster ID (CAPOSC v1)
+		c.clusterID = []string{self.ClusterID()}
+		if self.SubnetID != "" {
+			// alternate cluster ID (CAPOSC v0)
+			subs, err := api.OAPI().ReadSubnets(ctx, osc.ReadSubnetsRequest{
+				Filters: &osc.FiltersSubnet{SubnetIds: &[]string{self.SubnetID}},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error finding self subnets: %w", err)
+			}
+			if len(subs) == 1 {
+				clusterID := getClusterIDFromTags(subs[0].GetTags())
+				if clusterID != "" && !slices.Contains(c.clusterID, clusterID) {
+					c.clusterID = append(c.clusterID, clusterID)
+				}
+			}
+		}
+	}
+	if len(c.clusterID) > 0 {
+		klog.FromContext(ctx).V(3).Info(fmt.Sprintf("Allowed cluster IDs: %v", c.clusterID))
 	}
 	return c, nil
 }
@@ -53,12 +77,12 @@ func NewWith(api oapi.Clienter, self *VM, clusterID string) *Cloud {
 			AvailabilityZone: self.AvailabilityZone,
 		},
 		Self:      self,
-		clusterID: clusterID,
+		clusterID: []string{clusterID},
 	}
 }
 
 func (c *Cloud) Initialize(ctx context.Context, kube clientset.Interface) {
-	if c.clusterID != "" {
+	if len(c.clusterID) > 0 {
 		return
 	}
 	logger := klog.FromContext(ctx)
@@ -68,6 +92,30 @@ func (c *Cloud) Initialize(ctx context.Context, kube clientset.Interface) {
 		logger.V(3).Error(err, "Unable to infer cluster ID")
 		return
 	}
-	c.clusterID = string(ns.UID)
-	logger.V(3).Info("Inferred cluster ID: " + c.clusterID)
+	c.clusterID = []string{string(ns.UID)}
+	logger.V(3).Info("Inferred cluster ID: " + string(ns.UID))
+}
+
+func (c *Cloud) sameCluster(tags []osc.ResourceTag) bool {
+	return slices.Contains(c.clusterID, getClusterIDFromTags(tags))
+}
+
+func (c *Cloud) mainSGTagKey() string {
+	if len(c.clusterID) == 0 {
+		return ""
+	}
+	return mainSGTagKey(c.clusterID[0])
+}
+
+func (c *Cloud) clusterIDTagKey() string {
+	if len(c.clusterID) == 0 {
+		return ""
+	}
+	return clusterIDTagKey(c.clusterID[0])
+}
+
+func (c *Cloud) clusterIDTagKeys() []string {
+	return utils.Map(c.clusterID, func(c string) (string, bool) {
+		return clusterIDTagKey(c), true
+	})
 }

--- a/cloud-controller-manager/osc/cloud/tags.go
+++ b/cloud-controller-manager/osc/cloud/tags.go
@@ -41,7 +41,7 @@ const (
 	ResourceLifecycleShared = "shared"
 )
 
-func getLBUClusterID(tags []osc.ResourceTag) string {
+func getClusterIDFromTags(tags []osc.ResourceTag) string {
 	for _, t := range tags {
 		if strings.HasPrefix(t.GetKey(), ClusterIDTagKeyPrefix) {
 			return strings.TrimPrefix(t.GetKey(), ClusterIDTagKeyPrefix)
@@ -50,7 +50,7 @@ func getLBUClusterID(tags []osc.ResourceTag) string {
 	return ""
 }
 
-func getLBUServiceName(tags []osc.ResourceTag) string {
+func getServiceNameFromTags(tags []osc.ResourceTag) string {
 	for _, t := range tags {
 		if t.GetKey() == ServiceNameTagKey {
 			return t.GetValue()

--- a/cloud-controller-manager/osc/provider.go
+++ b/cloud-controller-manager/osc/provider.go
@@ -71,7 +71,7 @@ func NewProvider(ctx context.Context, opts Options) (*Provider, error) {
 	}
 
 	self := c.Self
-	klog.V(3).Infof("Instance: %q", self.ID)
+	klog.V(3).Infof("Instance: %s", self.ID)
 	return &Provider{
 		opts:     opts,
 		cloud:    c,

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/outscale/cloud-provider-osc
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.5
 
 // Outscale imports
 require (


### PR DESCRIPTION
## Description

When a cluster was created with CAPOSC v0.4 and upgraded to CAPOSC v1, VMs, Subnets, LBUs might have mismached OscK8sClusterID tags.

* the subnet will always have a v0 tag,
* the VM might have a v0 or v1 tag (if nodes have been upgraded after the CAPOSC v1 upgrade),
* LBUs might have either a v0 or a v1 tag. 

The CCM now searches for both a v0 (in the host VM subnet) and a v1 tag (in the host VM) and will match LBUs and Subnets having either a v0 or v1 OscK8sClusterID tag.

Fixes: #562 

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
