### PR TITLE
🐛 fix: CCM crashes when unable to talk to OAPI

### DIFF
--- a/cloud-controller-manager/osc/oapi/oapi.go
+++ b/cloud-controller-manager/osc/oapi/oapi.go
@@ -14,6 +14,7 @@ import (
 
 	osc "github.com/outscale/osc-sdk-go/v2"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -33,11 +34,11 @@ var (
 
 func (c *OscClient) CheckCredentials(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
-	req := osc.ReadVmsRequest{}
+	req := osc.ReadVmsRequest{DryRun: ptr.To(true)}
 	logger.V(4).Info("Check credentials", "OAPI", "ReadVms")
 	_, httpRes, err := c.api.VmApi.ReadVms(c.WithAuth(ctx)).ReadVmsRequest(req).Execute()
 	switch {
-	case err == nil || httpRes.StatusCode == http.StatusTooManyRequests:
+	case err == nil || (httpRes != nil && httpRes.StatusCode == http.StatusTooManyRequests):
 		return nil
 	case httpRes == nil:
 		logger.V(3).Error(err, "OAPI error", "OAPI", "ReadVms")

--- a/cloud-controller-manager/osc/oapi/oapi_test.go
+++ b/cloud-controller-manager/osc/oapi/oapi_test.go
@@ -21,4 +21,12 @@ func TestCheckCredentials(t *testing.T) {
 		err = api.OAPI().CheckCredentials(t.Context())
 		require.ErrorIs(t, err, oapi.ErrInvalidCredentials)
 	})
+	t.Run("CheckCredentials returns an error in case of a network problem", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		api, err := oapi.NewClient("foo")
+		require.NoError(t, err)
+		err = api.OAPI().CheckCredentials(t.Context())
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Description

When the CCM is unable to talk to Outscale API (firewall, DNS, ...), it panics during init.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
