### PR TITLE
✨ feat(metadata): add net and role labels on nodes

### DIFF
--- a/ccm/cloud/vm.go
+++ b/ccm/cloud/vm.go
@@ -29,6 +29,7 @@ type VM struct {
 	NetID     *string
 	SubnetID  *string
 	VmType    string
+	Roles     []string
 
 	cloudVm *osc.Vm
 }
@@ -43,6 +44,11 @@ func FromOscVm(vm *osc.Vm) *VM {
 		SubnetID:  vm.SubnetId,
 		SubRegion: vm.Placement.SubregionName,
 		cloudVm:   vm,
+	}
+	for _, t := range vm.Tags {
+		if after, ok := strings.CutPrefix(t.Key, tags.RolePrefix); ok {
+			v.Roles = append(v.Roles, after)
+		}
 	}
 	v.Region = v.SubRegion[:len(v.SubRegion)-1]
 	return v

--- a/ccm/helpers_test.go
+++ b/ccm/helpers_test.go
@@ -56,6 +56,8 @@ var (
 		Tags: []osc.ResourceTag{{
 			Key:   tags.VmNodeName,
 			Value: vmNodeName,
+		}, {
+			Key: tags.RoleKey("worker"),
 		}},
 		SubnetId:       ptr.To("subnet-bar"),
 		NetId:          ptr.To("net-bar"),

--- a/ccm/instances_v2.go
+++ b/ccm/instances_v2.go
@@ -15,6 +15,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	NetLabel        = "topology.outscale.com/net"
+	RoleLabelPrefix = "role.outscale.com/"
+)
+
 // InstanceExists indicates whether a given node exists according to the cloud provider
 func (c *Provider) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	vm, err := c.getVmByNodeName(ctx, node.Name)
@@ -47,7 +52,7 @@ func (c *Provider) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudp
 	if err != nil {
 		return nil, err
 	}
-	labels := make(map[string]string, len(c.opts.NodeLabels))
+	labels := make(map[string]string, len(c.opts.NodeLabels)+2)
 	for k, v := range c.opts.nodeLabelTemplates {
 		str := strings.Builder{}
 		err := v.Execute(&str, vm)
@@ -56,6 +61,12 @@ func (c *Provider) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudp
 			continue
 		}
 		labels[k] = str.String()
+	}
+	if vm.NetID != nil {
+		labels[NetLabel] = *vm.NetID
+	}
+	for _, role := range vm.Roles {
+		labels[RoleLabelPrefix+role] = ""
 	}
 	return &cloudprovider.InstanceMetadata{
 		ProviderID:       vm.ProviderID(),

--- a/ccm/instances_v2_test.go
+++ b/ccm/instances_v2_test.go
@@ -85,7 +85,10 @@ func TestInstanceMetadata(t *testing.T) {
 				{Type: v1.NodeInternalDNS, Address: "10.0.0.10.eu-west-2.compute.internal"},
 				{Type: v1.NodeHostName, Address: "10.0.0.10.eu-west-2.compute.internal"},
 			},
-			AdditionalLabels: map[string]string{},
+			AdditionalLabels: map[string]string{
+				ccm.NetLabel:                   "net-bar",
+				ccm.RoleLabelPrefix + "worker": "",
+			},
 		}, meta)
 	})
 	t.Run("Additional labels can be set", func(t *testing.T) {
@@ -106,6 +109,7 @@ func TestInstanceMetadata(t *testing.T) {
 			"label.foo":       "foo",
 			"label.bar":       "barbar",
 			"label.SubRegion": "eu-west-2a",
+			ccm.NetLabel:      "net-bar",
 		}, meta.AdditionalLabels)
 	})
 }

--- a/tests/e2e/node.go
+++ b/tests/e2e/node.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint: staticcheck
 	"github.com/onsi/gomega"
+	"github.com/outscale/cloud-provider-osc/ccm"
 	"github.com/outscale/cloud-provider-osc/labeler"
 	e2eutils "github.com/outscale/cloud-provider-osc/tests/e2e/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,16 @@ var _ = Describe("[e2e][node] Adding labels to nodes", func() {
 		framework.ExpectNoError(err)
 		for _, node := range lst.Items {
 			gomega.Expect(node.Labels).To(gomega.HaveKey("clilabel"))
+		}
+	})
+
+	It("sets the net label", func() {
+		cl := f.ClientSet.CoreV1().Nodes()
+		lst, err := cl.List(context.Background(), metav1.ListOptions{})
+		framework.ExpectNoError(err)
+		for _, node := range lst.Items {
+			// The CI does not set roles on nodes
+			gomega.Expect(node.Labels).To(gomega.HaveKey(ccm.NetLabel))
 		}
 	})
 })


### PR DESCRIPTION
## Description

This PR adds labels on nodes:
* net ID (can be used to target loadbalancer backend nodes in multi-VPC clusters),
* role (as defined by the [Outscale Cluster-API provider](https://github.com/outscale/cluster-api-provider-outscale)).

```
labels:
  topology.outscale.com/net: vpc-xxx
  role.outscale.com/worker: ""
```

> Note: as the role may be a user-defined value, the standard `node-role.kubernetes.io/<role>` label is not used.

Refs: #568

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [x] E2E tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
