### PR TITLE
🐛 fix(InstanceMetadata): fix crash on terminated VM

### DIFF
--- a/ccm/cloud/vm.go
+++ b/ccm/cloud/vm.go
@@ -143,13 +143,6 @@ func (c *Cloud) GetVMsByNodeName(ctx context.Context, nodeNames ...string) ([]VM
 	resp, err := c.api.OAPI().ReadVms(ctx, osc.ReadVmsRequest{
 		Filters: &osc.FiltersVm{
 			TagKeys: ptr.To(c.clusterIDTagKeys()),
-			VmStateNames: &[]osc.VmState{
-				osc.VmStatePending,
-				osc.VmStateRunning,
-				osc.VmStateStopping,
-				osc.VmStateStopped,
-				osc.VmStateShuttingDown,
-			},
 		},
 	})
 	switch {
@@ -161,8 +154,8 @@ func (c *Cloud) GetVMsByNodeName(ctx context.Context, nodeNames ...string) ([]VM
 	vms := make([]VM, 0, len(nodeNames))
 	for _, nodeName := range nodeNames {
 		for _, sdkVM := range *resp.Vms {
-			if tags.Has(sdkVM.Tags, tags.VmNodeName, nodeName) ||
-				mapInstanceToNodeName(&sdkVM) == types.NodeName(nodeName) {
+			if sdkVM.State != osc.VmStateTerminated && (tags.Has(sdkVM.Tags, tags.VmNodeName, nodeName) ||
+				mapInstanceToNodeName(&sdkVM) == types.NodeName(nodeName)) {
 				vms = append(vms, *FromOscVm(&sdkVM))
 			}
 		}
@@ -221,14 +214,16 @@ func (c *Cloud) GetVMsByID(ctx context.Context, vmIDs ...string) ([]VM, error) {
 	}
 	vms := make([]VM, 0, len(*resp.Vms))
 	for _, sdkVM := range *resp.Vms {
-		vms = append(vms, *FromOscVm(&sdkVM))
+		if sdkVM.State != osc.VmStateTerminated {
+			vms = append(vms, *FromOscVm(&sdkVM))
+		}
 	}
 	return vms, nil
 }
 
 // mapInstanceToNodeName maps an OSC instance to a k8s NodeName, by extracting the PrivateDNSName
 func mapInstanceToNodeName(i *osc.Vm) types.NodeName {
-	return types.NodeName(*i.PrivateDnsName)
+	return types.NodeName(ptr.From(i.PrivateDnsName))
 }
 
 func ParseProviderID(providerID string) (subregion, vmID string, err error) {

--- a/ccm/helpers_test.go
+++ b/ccm/helpers_test.go
@@ -93,13 +93,6 @@ func expectVMs(mock *mocks_osc.MockClient, vms ...osc.Vm) {
 		ReadVms(gomock.Any(), gomock.Eq(osc.ReadVmsRequest{
 			Filters: &osc.FiltersVm{
 				TagKeys: &[]string{"OscK8sClusterID/foo"},
-				VmStateNames: &[]osc.VmState{
-					osc.VmStatePending,
-					osc.VmStateRunning,
-					osc.VmStateStopping,
-					osc.VmStateStopped,
-					osc.VmStateShuttingDown,
-				},
 			},
 		})).
 		Return(&osc.ReadVmsResponse{Vms: &vms}, nil)

--- a/ccm/instances_test.go
+++ b/ccm/instances_test.go
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-3-Clause
 package ccm_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/outscale/cloud-provider-osc/ccm"
@@ -34,7 +33,7 @@ func TestNodeAddresses(t *testing.T) {
 		})
 		c, _, _ := newAPI(t, vm, []string{"foo"})
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		addrs, err := p.NodeAddresses(context.TODO(), vm.NodeName)
+		addrs, err := p.NodeAddresses(t.Context(), vm.NodeName)
 		require.NoError(t, err)
 		assert.Equal(t, []v1.NodeAddress{
 			{Type: v1.NodeInternalIP, Address: "10.0.0.10"},
@@ -56,7 +55,7 @@ func TestNodeAddresses(t *testing.T) {
 		})
 		c, _, _ := newAPI(t, vm, []string{"foo"})
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		addrs, err := p.NodeAddresses(context.TODO(), vm.NodeName)
+		addrs, err := p.NodeAddresses(t.Context(), vm.NodeName)
 		require.NoError(t, err)
 		assert.Equal(t, []v1.NodeAddress{
 			{Type: v1.NodeInternalIP, Address: "10.0.0.10"},
@@ -94,7 +93,7 @@ func TestNodeAddresses(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, *sdkself, *sdkvm)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		addrs, err := p.NodeAddresses(context.TODO(), types.NodeName(name))
+		addrs, err := p.NodeAddresses(t.Context(), types.NodeName(name))
 		require.NoError(t, err)
 		assert.Equal(t, []v1.NodeAddress{
 			{Type: v1.NodeInternalIP, Address: "10.0.0.10"},
@@ -125,7 +124,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		})).
 		Return(&osc.ReadVmsResponse{Vms: &[]osc.Vm{*sdkvm}}, nil)
 	p := ccm.NewProviderWith(c, nil, ccm.Options{})
-	addrs, err := p.NodeAddressesByProviderID(context.TODO(), providerID)
+	addrs, err := p.NodeAddressesByProviderID(t.Context(), providerID)
 	require.NoError(t, err)
 	assert.Equal(t, []v1.NodeAddress{
 		{Type: v1.NodeInternalIP, Address: "10.0.0.10"},
@@ -154,7 +153,7 @@ func TestInstanceTypeByProviderID(t *testing.T) {
 		})).
 		Return(&osc.ReadVmsResponse{Vms: &[]osc.Vm{*sdkvm}}, nil)
 	p := ccm.NewProviderWith(c, nil, ccm.Options{})
-	typ, err := p.InstanceTypeByProviderID(context.TODO(), providerID)
+	typ, err := p.InstanceTypeByProviderID(t.Context(), providerID)
 	require.NoError(t, err)
 	assert.Equal(t, sdkvm.VmType, typ)
 }
@@ -171,7 +170,7 @@ func TestInstanceID(t *testing.T) {
 		})
 		c, _, _ := newAPI(t, vm, []string{"foo"})
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		id, err := p.InstanceID(context.TODO(), vm.NodeName)
+		id, err := p.InstanceID(t.Context(), vm.NodeName)
 		require.NoError(t, err)
 		assert.Equal(t, "/eu-west-2a/i-foo", id)
 	})
@@ -202,7 +201,7 @@ func TestInstanceID(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, *sdkself, *sdkvm)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		id, err := p.InstanceID(context.TODO(), types.NodeName(name))
+		id, err := p.InstanceID(t.Context(), types.NodeName(name))
 		require.NoError(t, err)
 		assert.Equal(t, "/eu-west-2a/i-foo", id)
 	})

--- a/ccm/instances_v2_test.go
+++ b/ccm/instances_v2_test.go
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-3-Clause
 package ccm_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/outscale/cloud-provider-osc/ccm"
@@ -23,7 +22,7 @@ func TestInstanceExists(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, sdkSelf, sdkVM)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		exists, err := p.InstanceExists(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		exists, err := p.InstanceExists(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.True(t, exists)
 	})
@@ -31,17 +30,18 @@ func TestInstanceExists(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, sdkSelf)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		exists, err := p.InstanceExists(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		exists, err := p.InstanceExists(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
 	t.Run("If the instance is terminated, return false", func(t *testing.T) {
 		sdkTerminated := sdkVM
 		sdkTerminated.State = osc.VmStateTerminated
+		sdkTerminated.PrivateDnsName = nil
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, sdkSelf, sdkTerminated)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		exists, err := p.InstanceExists(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		exists, err := p.InstanceExists(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -52,7 +52,7 @@ func TestInstanceShutdown(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, sdkSelf, sdkVM)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		shut, err := p.InstanceShutdown(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		shut, err := p.InstanceShutdown(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.False(t, shut)
 	})
@@ -62,9 +62,19 @@ func TestInstanceShutdown(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, sdkSelf, sdkVM)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		shut, err := p.InstanceShutdown(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		shut, err := p.InstanceShutdown(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.True(t, shut)
+	})
+	t.Run("If the instance is terminated, return a not found error", func(t *testing.T) {
+		sdkTerminated := sdkVM
+		sdkTerminated.State = osc.VmStateTerminated
+		sdkTerminated.PrivateDnsName = nil
+		c, mock, _ := newAPI(t, self, []string{"foo"})
+		expectVMs(mock, sdkSelf, sdkTerminated)
+		p := ccm.NewProviderWith(c, nil, ccm.Options{})
+		_, err := p.InstanceShutdown(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		require.ErrorIs(t, err, cloudprovider.InstanceNotFound)
 	})
 }
 
@@ -73,7 +83,7 @@ func TestInstanceMetadata(t *testing.T) {
 		c, mock, _ := newAPI(t, self, []string{"foo"})
 		expectVMs(mock, sdkSelf, sdkVM)
 		p := ccm.NewProviderWith(c, nil, ccm.Options{})
-		meta, err := p.InstanceMetadata(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		meta, err := p.InstanceMetadata(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.Equal(t, &cloudprovider.InstanceMetadata{
 			ProviderID:   "aws:///eu-west-2a/i-foo",
@@ -103,7 +113,7 @@ func TestInstanceMetadata(t *testing.T) {
 				"label.SubRegion": "{{ .SubRegion }}",
 			},
 		})
-		meta, err := p.InstanceMetadata(context.TODO(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		meta, err := p.InstanceMetadata(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
 			"label.foo":       "foo",
@@ -111,5 +121,15 @@ func TestInstanceMetadata(t *testing.T) {
 			"label.SubRegion": "eu-west-2a",
 			ccm.NetLabel:      "net-bar",
 		}, meta.AdditionalLabels)
+	})
+	t.Run("If the instance is terminated, return a not found error", func(t *testing.T) {
+		sdkTerminated := sdkVM
+		sdkTerminated.State = osc.VmStateTerminated
+		sdkTerminated.PrivateDnsName = nil
+		c, mock, _ := newAPI(t, self, []string{"foo"})
+		expectVMs(mock, sdkSelf, sdkTerminated)
+		p := ccm.NewProviderWith(c, nil, ccm.Options{})
+		_, err := p.InstanceMetadata(t.Context(), &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: vmNodeName}})
+		require.ErrorIs(t, err, cloudprovider.InstanceNotFound)
 	})
 }


### PR DESCRIPTION
## Description

InstanceMetadata will crash on terminated VMs.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
